### PR TITLE
Improve http example

### DIFF
--- a/packages/leancode_cubit_utils/README.md
+++ b/packages/leancode_cubit_utils/README.md
@@ -13,15 +13,21 @@ Import the package:
 
 # Usage
 
-The collection of utilities in the package can be divided into two subsets. [Single Request Utils](#single-request-utils) are used for creating pages where a single request is made to retrieve data, which is then displayed. [Pagination Utils](#pagination-utils) are used for creating pages containing paginated lists. 
+The collection of utilities in the package can be divided into two subsets. [Single Request Utils](#single-request-utils) are used for creating pages where a single request is made to retrieve data which is then displayed. [Pagination Utils](#pagination-utils) are used for creating pages containing paginated lists. For both cases it is possible to implement variants that use different API clients. 
 
-Implementation of cubits for handling [CQRS](https://pub.dev/packages/cqrs) queries is covered in [`leancode_cubit_utils_cqrs`][leancode_cubit_utils_cqrs] but for both cases it is possible to implement variants that use different API clients.
+Implementation of cubits for handling [CQRS](https://pub.dev/packages/cqrs) queries is covered in [`leancode_cubit_utils_cqrs`][leancode_cubit_utils_cqrs]. 
 
 ## Single Request Utils
 
 ### `RequestCubit`
 
-`RequestCubit` is used to execute a single API request. It has four generic arguments: TRes, TData, TOut and TError. TRes specifies what the request returns, TData specifies what is kept in TRes as response body, TOut determines which model we want to emit as data in the state, TError defines error's type. In the example below, `HttpRequestCubit` provides the generic http implementation that can be used while defining all needed `RequestCubits`.
+`RequestCubit` is used to execute a single API request. It has four generic arguments:
+- `TRes` specifies what the request returns,
+- `TData` specifies what is kept in TRes as response body,
+- `TOut` determines which model we want to emit as data in the state,
+- `TError` defines error's type. In the example below.
+
+`HttpRequestCubit` in the example below provides the generic http implementation that can be used while defining all needed `RequestCubits`.
 
 ```dart
 /// Base class for http request cubits.
@@ -130,7 +136,7 @@ RequestCubitBuilder(
     )
 ```
 
-As you may see `onInitial`, `onLoading` and `onError` are marked as optional parameter. In many projects each of those widgets are the same for each page. So in order to eliminate even more boilerplate code, instead of passing them all each time you want to use `RequestCubitBuilder`, you can define them globally and provider in the whole app using [`RequestLayoutConfigProvider`](#requestlayoutconfigprovider).
+As you may see `onInitial`, `onLoading` and `onError` are marked as optional parameter. In many projects each of those widgets are the same for each page. So in order to eliminate even more boilerplate code, instead of passing them all each time you want to use `RequestCubitBuilder`, you can define them globally and provide in the whole app using [`RequestLayoutConfigProvider`](#requestlayoutconfigprovider).
 
 ### `RequestLayoutConfigProvider`
 
@@ -227,7 +233,7 @@ It also takes optional `controller`, `physics` and numerous optional builders:
 - `nextPageLoadingBuilder` - builds a widget which is displayed under the last element of the list while next page is being fetched,
 - `nextPageErrorBuilder` - builds a widget which is displayed under the last element of the list if fetching the next page fails.
 
-You can provider most of those builder globally in the whole app using [`PaginatedLayoutConfig`](#paginatedlayoutconfig).
+You can provide most of these builders globally in the whole app using [`PaginatedLayoutConfig`](#paginatedlayoutconfig).
 
 ### `PaginatedCubitBuilder`
 `PaginatedCubitBuilder` is a widget which rebuilds itself when state of the paginated cubit changes. It takes two required parameter:

--- a/packages/leancode_cubit_utils/example/lib/main.dart
+++ b/packages/leancode_cubit_utils/example/lib/main.dart
@@ -13,7 +13,6 @@ import 'package:provider/provider.dart';
 class Routes {
   static const home = '/';
   static const simpleRequest = '/simple-request';
-  static const simpleRequestHook = '/simple-request-hook';
   static const paginatedCubit = '/paginated-cubit';
 }
 
@@ -90,7 +89,6 @@ class MainApp extends StatelessWidget {
         routes: <String, WidgetBuilder>{
           Routes.home: (_) => const HomePage(),
           Routes.simpleRequest: (_) => const RequestScreen(),
-          Routes.simpleRequestHook: (_) => const RequestHookScreen(),
           Routes.paginatedCubit: (_) => const PaginatedCubitScreen(),
         },
       );

--- a/packages/leancode_cubit_utils/example/lib/pages/common.dart
+++ b/packages/leancode_cubit_utils/example/lib/pages/common.dart
@@ -1,0 +1,56 @@
+import 'package:example/http/status_codes.dart';
+import 'package:http/http.dart' as http;
+import 'package:leancode_cubit_utils/leancode_cubit_utils.dart';
+
+mixin PreRequestRun<TData, TItem>
+    on PreRequest<http.Response, String, TData, TItem> {
+  @override
+  Future<PaginatedState<TData, TItem>> run(
+      PaginatedState<TData, TItem> state) async {
+    try {
+      final result = await request(state);
+
+      if (result.statusCode == StatusCode.ok.value) {
+        return state.copyWith(
+          data: map(result.body, state),
+          preRequestSuccess: true,
+        );
+      } else {
+        try {
+          return handleError(state.copyWithError(result.statusCode));
+        } catch (e) {
+          return state.copyWithError(e);
+        }
+      }
+    } catch (e) {
+      try {
+        return handleError(state.copyWithError(e));
+      } catch (e) {
+        return state.copyWithError(e);
+      }
+    }
+  }
+}
+
+mixin RequestHandleResult<TOut>
+    on RequestCubit<http.Response, String, TOut, int> {
+  @override
+  Future<RequestState<TOut, int>> handleResult(
+    http.Response result,
+  ) async {
+    if (result.statusCode == StatusCode.ok.value) {
+      logger.info('Request success. Data: ${result.body}');
+      return RequestSuccessState(map(result.body));
+    } else {
+      logger.severe('Request error. Status code: ${result.statusCode}');
+      try {
+        return await handleError(RequestErrorState(error: result.statusCode));
+      } catch (e, s) {
+        logger.severe(
+          'Processing error failed. Exception: $e. Stack trace: $s',
+        );
+        return RequestErrorState(exception: e, stackTrace: s);
+      }
+    }
+  }
+}

--- a/packages/leancode_cubit_utils/example/lib/pages/common.dart
+++ b/packages/leancode_cubit_utils/example/lib/pages/common.dart
@@ -2,6 +2,9 @@ import 'package:example/http/status_codes.dart';
 import 'package:http/http.dart' as http;
 import 'package:leancode_cubit_utils/leancode_cubit_utils.dart';
 
+/// [PreRequestRun] and [RequestHandleResult] can be used repeatedly
+/// in cubits handling http.
+
 mixin PreRequestRun<TData, TItem>
     on PreRequest<http.Response, String, TData, TItem> {
   @override

--- a/packages/leancode_cubit_utils/example/lib/pages/home_page.dart
+++ b/packages/leancode_cubit_utils/example/lib/pages/home_page.dart
@@ -21,11 +21,6 @@ class HomePage extends StatelessWidget {
             ),
             const SizedBox(height: 16),
             ElevatedButton(
-              onPressed: () => pushNamed(Routes.simpleRequestHook),
-              child: const Text('Simple request hook page'),
-            ),
-            const SizedBox(height: 16),
-            ElevatedButton(
               onPressed: () => pushNamed(Routes.paginatedCubit),
               child: const Text('Paginated cubit page'),
             ),

--- a/packages/leancode_cubit_utils/example/lib/pages/paginated/simple_paginated_cubit.dart
+++ b/packages/leancode_cubit_utils/example/lib/pages/paginated/simple_paginated_cubit.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:example/http/status_codes.dart';
+import 'package:example/pages/common.dart';
 import 'package:http/http.dart' as http;
 import 'package:equatable/equatable.dart';
 import 'package:example/pages/paginated/api.dart';
@@ -37,7 +38,8 @@ class AdditionalData with EquatableMixin {
 }
 
 class FiltersPreRequest
-    extends PreRequest<http.Response, String, AdditionalData, User> {
+    extends PreRequest<http.Response, String, AdditionalData, User>
+    with PreRequestRun {
   FiltersPreRequest({
     required this.api,
   });
@@ -63,33 +65,6 @@ class FiltersPreRequest
           .where((e) => filters.availableFilters.contains(e))
           .toSet(),
     );
-  }
-
-  @override
-  Future<PaginatedState<AdditionalData, User>> run(
-      PaginatedState<AdditionalData, User> state) async {
-    try {
-      final result = await request(state);
-
-      if (result.statusCode == StatusCode.ok.value) {
-        return state.copyWith(
-          data: map(result.body, state),
-          preRequestSuccess: true,
-        );
-      } else {
-        try {
-          return handleError(state.copyWithError(result.statusCode));
-        } catch (e) {
-          return state.copyWithError(e);
-        }
-      }
-    } catch (e) {
-      try {
-        return handleError(state.copyWithError(e));
-      } catch (e) {
-        return state.copyWithError(e);
-      }
-    }
   }
 }
 

--- a/packages/leancode_cubit_utils/example/lib/pages/paginated/simple_paginated_cubit.dart
+++ b/packages/leancode_cubit_utils/example/lib/pages/paginated/simple_paginated_cubit.dart
@@ -37,9 +37,7 @@ class AdditionalData with EquatableMixin {
       );
 }
 
-class FiltersPreRequest
-    extends PreRequest<http.Response, String, AdditionalData, User>
-    with PreRequestRun {
+class FiltersPreRequest extends HttpPreRequest<AdditionalData, User> {
   FiltersPreRequest({
     required this.api,
   });

--- a/packages/leancode_cubit_utils/example/lib/pages/request/request_page.dart
+++ b/packages/leancode_cubit_utils/example/lib/pages/request/request_page.dart
@@ -6,65 +6,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:http/http.dart' as http;
 import 'package:leancode_cubit_utils/leancode_cubit_utils.dart';
-import 'package:leancode_hooks/leancode_hooks.dart';
 
-class UserRequestCubit extends RequestCubit<http.Response, String, User, int>
-    with RequestHandleResult {
-  UserRequestCubit(
-    this._request,
-  ) : super('UserRequestCubit');
-
-  final Request<http.Response> _request;
+class UserRequestCubit extends HttpRequestCubit<User> {
+  UserRequestCubit({required super.client}) : super('UserRequestCubit');
 
   @override
-  Future<http.Response> request() => _request();
+  Future<http.Response> request() => client.get(Uri.parse('success'));
 
   @override
   User map(String data) =>
       User.fromJson(jsonDecode(data) as Map<String, dynamic>);
-}
-
-class RequestHookScreen extends StatelessWidget {
-  const RequestHookScreen({super.key});
-
-  @override
-  Widget build(BuildContext context) => const RequestHookPage();
-}
-
-class RequestHookPage extends HookWidget {
-  const RequestHookPage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    final userCubit = useBloc(
-      () => UserRequestCubit(
-        () => context.read<http.Client>().get(Uri.parse('success')),
-      )..run(),
-      [],
-    );
-
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Simple request page'),
-      ),
-      body: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Center(
-            child: RequestCubitBuilder(
-              cubit: userCubit,
-              builder: (context, data) => Text('${data.name} ${data.surname}'),
-            ),
-          ),
-          const SizedBox(height: 16),
-          ElevatedButton(
-            onPressed: userCubit.refresh,
-            child: const Text('Refresh'),
-          ),
-        ],
-      ),
-    );
-  }
 }
 
 class RequestScreen extends StatelessWidget {
@@ -72,9 +23,8 @@ class RequestScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => BlocProvider(
-        create: (context) => UserRequestCubit(
-          () => context.read<http.Client>().get(Uri.parse('success')),
-        )..run(),
+        create: (context) =>
+            UserRequestCubit(client: context.read<http.Client>())..run(),
         child: const RequestPage(),
       );
 }

--- a/packages/leancode_cubit_utils/example/lib/pages/request/request_page.dart
+++ b/packages/leancode_cubit_utils/example/lib/pages/request/request_page.dart
@@ -1,14 +1,15 @@
 import 'dart:convert';
 
 import 'package:example/http/client.dart';
-import 'package:example/http/status_codes.dart';
+import 'package:example/pages/common.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:http/http.dart' as http;
 import 'package:leancode_cubit_utils/leancode_cubit_utils.dart';
 import 'package:leancode_hooks/leancode_hooks.dart';
 
-class UserRequestCubit extends RequestCubit<http.Response, String, User, int> {
+class UserRequestCubit extends RequestCubit<http.Response, String, User, int>
+    with RequestHandleResult {
   UserRequestCubit(
     this._request,
   ) : super('UserRequestCubit');
@@ -21,26 +22,6 @@ class UserRequestCubit extends RequestCubit<http.Response, String, User, int> {
   @override
   User map(String data) =>
       User.fromJson(jsonDecode(data) as Map<String, dynamic>);
-
-  @override
-  Future<RequestState<User, int>> handleResult(
-    http.Response result,
-  ) async {
-    if (result.statusCode == StatusCode.ok.value) {
-      logger.info('Request success. Data: ${result.body}');
-      return RequestSuccessState(map(result.body));
-    } else {
-      logger.severe('Request error. Status code: ${result.statusCode}');
-      try {
-        return await handleError(RequestErrorState(error: result.statusCode));
-      } catch (e, s) {
-        logger.severe(
-          'Processing error failed. Exception: $e. Stack trace: $s',
-        );
-        return RequestErrorState(exception: e, stackTrace: s);
-      }
-    }
-  }
 }
 
 class RequestHookScreen extends StatelessWidget {

--- a/packages/leancode_cubit_utils/example/pubspec.lock
+++ b/packages/leancode_cubit_utils/example/pubspec.lock
@@ -249,7 +249,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.4"
+    version: "0.1.0"
   leancode_hooks:
     dependency: "direct main"
     description:

--- a/packages/leancode_cubit_utils_cqrs/example/pubspec.lock
+++ b/packages/leancode_cubit_utils_cqrs/example/pubspec.lock
@@ -257,7 +257,7 @@ packages:
       path: "../../leancode_cubit_utils"
       relative: true
     source: path
-    version: "0.0.4"
+    version: "0.1.0"
   leancode_cubit_utils_cqrs:
     dependency: "direct main"
     description:
@@ -559,5 +559,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
+  dart: ">=3.3.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
Create base classes for http implementation of `RequestCubit` and `PreRequest`.
Also, remove the hook example as there is no `useQuery` method anymore.