### PR TITLE
Use new leancode_cubit_utils version in leancode_cubit_utils_cqrs

### DIFF
--- a/packages/leancode_cubit_utils_cqrs/CHANGELOG.md
+++ b/packages/leancode_cubit_utils_cqrs/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+* Use `leancode_cubit_utils` version `0.3.1`
+
 ## 0.2.0
 
 * Add:

--- a/packages/leancode_cubit_utils_cqrs/pubspec.yaml
+++ b/packages/leancode_cubit_utils_cqrs/pubspec.yaml
@@ -1,6 +1,6 @@
 name: leancode_cubit_utils_cqrs
 description: An extension of leancode_cubit_utils that provides cqrs support.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/leancodepl/leancode_cubit_utils
 
 environment:
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_bloc: ^8.0.0
-  leancode_cubit_utils: ^0.2.0
+  leancode_cubit_utils: ^0.3.1
   leancode_hooks: ^0.0.6
 
 dev_dependencies:


### PR DESCRIPTION
Use `leancode_cubit_utils` version `3.1.0` in `leancode_cubit_utils_cqrs`