### PR TITLE
Prevent request cubits from emitting after close

### DIFF
--- a/packages/leancode_cubit_utils/lib/src/request/request_cubit.dart
+++ b/packages/leancode_cubit_utils/lib/src/request/request_cubit.dart
@@ -52,11 +52,21 @@ abstract class BaseRequestCubit<TRes, TOut, TError>
 
   CancelableOperation<TRes>? _operation;
 
+  void _emitIfOpen(RequestState<TOut, TError> state) {
+    if (!isClosed) {
+      emit(state);
+    }
+  }
+
   Future<void> _run(
     Future<TRes> Function() callback, {
     bool isRefresh = false,
   }) async {
     try {
+      if (isClosed) {
+        return;
+      }
+
       switch (requestMode ?? RequestCubitConfig.requestMode) {
         case RequestMode.replace:
           await _operation?.cancel();
@@ -67,14 +77,18 @@ abstract class BaseRequestCubit<TRes, TOut, TError>
           }
       }
 
+      if (isClosed) {
+        return;
+      }
+
       if (state
           case RequestSuccessState(:final data) ||
               RequestRefreshingState(:final data) when isRefresh) {
         logger.info('Refreshing request.');
-        emit(RequestRefreshingState(data));
+        _emitIfOpen(RequestRefreshingState(data));
       } else {
         logger.info('Request started.');
-        emit(RequestLoadingState());
+        _emitIfOpen(RequestLoadingState());
       }
 
       _operation = CancelableOperation.fromFuture(
@@ -89,18 +103,30 @@ abstract class BaseRequestCubit<TRes, TOut, TError>
         return;
       }
 
-      emit(await handleResult(result));
+      final handledResult = await handleResult(result);
+      _emitIfOpen(handledResult);
     } catch (e, s) {
       logger.severe('Request error. Exception: $e. Stack trace: $s');
       try {
-        emit(await handleError(RequestErrorState(exception: e, stackTrace: s)));
+        final handledError = await handleError(
+          RequestErrorState(exception: e, stackTrace: s),
+        );
+        _emitIfOpen(handledError);
       } catch (e, s) {
         logger.severe(
           'Processing error failed. Exception: $e. Stack trace: $s',
         );
-        emit(RequestErrorState<TOut, TError>(exception: e, stackTrace: s));
+        _emitIfOpen(
+          RequestErrorState<TOut, TError>(exception: e, stackTrace: s),
+        );
       }
     }
+  }
+
+  @override
+  Future<void> close() async {
+    await _operation?.cancel();
+    return super.close();
   }
 
   /// Handles the given [errorState] and returns the corresponding state.

--- a/packages/leancode_cubit_utils/lib/src/request/request_cubit.dart
+++ b/packages/leancode_cubit_utils/lib/src/request/request_cubit.dart
@@ -103,10 +103,18 @@ abstract class BaseRequestCubit<TRes, TOut, TError>
         return;
       }
 
+      if (isClosed) {
+        return;
+      }
+
       final handledResult = await handleResult(result);
       _emitIfOpen(handledResult);
     } catch (e, s) {
       logger.severe('Request error. Exception: $e. Stack trace: $s');
+      if (isClosed) {
+        return;
+      }
+
       try {
         final handledError = await handleError(
           RequestErrorState(exception: e, stackTrace: s),
@@ -116,6 +124,10 @@ abstract class BaseRequestCubit<TRes, TOut, TError>
         logger.severe(
           'Processing error failed. Exception: $e. Stack trace: $s',
         );
+        if (isClosed) {
+          return;
+        }
+
         _emitIfOpen(
           RequestErrorState<TOut, TError>(exception: e, stackTrace: s),
         );

--- a/packages/leancode_cubit_utils/test/request_cubit_test.dart
+++ b/packages/leancode_cubit_utils/test/request_cubit_test.dart
@@ -15,16 +15,16 @@ class _DelayedResultCubit extends RequestCubit<String, String, Object?> {
     : super('_DelayedResultCubit');
 
   final Completer<RequestState<String, Object?>> resultState;
-  final handleResultStarted = Completer<void>();
-  bool handleErrorCalled = false;
+  final resultHandlingStartedCompleter = Completer<void>();
+  bool errorHandlingWasCalled = false;
 
   @override
   Future<String> request() async => 'Result';
 
   @override
   Future<RequestState<String, Object?>> handleResult(String result) {
-    if (!handleResultStarted.isCompleted) {
-      handleResultStarted.complete();
+    if (!resultHandlingStartedCompleter.isCompleted) {
+      resultHandlingStartedCompleter.complete();
     }
 
     return resultState.future;
@@ -34,7 +34,7 @@ class _DelayedResultCubit extends RequestCubit<String, String, Object?> {
   Future<RequestErrorState<String, Object?>> handleError(
     RequestErrorState<String, Object?> errorState,
   ) async {
-    handleErrorCalled = true;
+    errorHandlingWasCalled = true;
     return errorState;
   }
 }
@@ -198,7 +198,7 @@ void main() {
         ),
         act: (cubit) async {
           final runFuture = cubit.run();
-          await cubit.handleResultStarted.future;
+          await cubit.resultHandlingStartedCompleter.future;
           await cubit.close();
           cubit.resultState.complete(RequestSuccessState('Result'));
           await runFuture;
@@ -213,14 +213,14 @@ void main() {
         ),
         act: (cubit) async {
           final runFuture = cubit.run();
-          await cubit.handleResultStarted.future;
+          await cubit.resultHandlingStartedCompleter.future;
           await cubit.close();
           cubit.resultState.completeError(Exception('Error'));
           await runFuture;
         },
         expect: () => <RequestState<String, Object?>>[RequestLoadingState()],
         verify: (cubit) {
-          expect(cubit.handleErrorCalled, isFalse);
+          expect(cubit.errorHandlingWasCalled, isFalse);
         },
       );
     });

--- a/packages/leancode_cubit_utils/test/request_cubit_test.dart
+++ b/packages/leancode_cubit_utils/test/request_cubit_test.dart
@@ -10,6 +10,26 @@ import 'utils/http_status_codes.dart';
 import 'utils/mocked_http_client.dart';
 import 'utils/test_request_cubit.dart';
 
+class _DelayedResultCubit extends RequestCubit<String, String, Object?> {
+  _DelayedResultCubit({required this.resultState})
+    : super('_DelayedResultCubit');
+
+  final Completer<RequestState<String, Object?>> resultState;
+  final handleResultStarted = Completer<void>();
+
+  @override
+  Future<String> request() async => 'Result';
+
+  @override
+  Future<RequestState<String, Object?>> handleResult(String result) {
+    if (!handleResultStarted.isCompleted) {
+      handleResultStarted.complete();
+    }
+
+    return resultState.future;
+  }
+}
+
 void main() {
   final client = MockedHttpClient();
 
@@ -137,6 +157,55 @@ void main() {
           isA<RequestErrorState<String, int>>(),
         ],
       );
+    });
+
+    group('close', () {
+      test('cancels an ongoing request without emitting after close', () async {
+        final request = Completer<http.Response>();
+        when(
+          () => client.get(Uri.parse('delayed')),
+        ).thenAnswer((_) => request.future);
+        final cubit = TestRequestCubit(
+          'TestRequestCubit',
+          client: client,
+          id: 'delayed',
+        );
+        final states = <RequestState<String, int>>[];
+        final subscription = cubit.stream.listen(states.add);
+
+        final runFuture = cubit.run();
+        await pumpEventQueue();
+
+        expect(states, hasLength(1));
+        expect(states.single, isA<RequestLoadingState<String, int>>());
+
+        await cubit.close();
+        request.complete(http.Response('Result', StatusCode.ok.value));
+
+        await expectLater(runFuture, completes);
+        expect(states, hasLength(1));
+
+        await subscription.cancel();
+      });
+
+      test('does not emit when closed while handling a result', () async {
+        final resultState = Completer<RequestState<String, Object?>>();
+        final cubit = _DelayedResultCubit(resultState: resultState);
+        final states = <RequestState<String, Object?>>[];
+        final subscription = cubit.stream.listen(states.add);
+
+        final runFuture = cubit.run();
+        await cubit.handleResultStarted.future;
+
+        await cubit.close();
+        resultState.complete(RequestSuccessState('Result'));
+
+        await expectLater(runFuture, completes);
+        expect(states, hasLength(1));
+        expect(states.single, isA<RequestLoadingState<String, Object?>>());
+
+        await subscription.cancel();
+      });
     });
   });
 

--- a/packages/leancode_cubit_utils/test/request_cubit_test.dart
+++ b/packages/leancode_cubit_utils/test/request_cubit_test.dart
@@ -16,6 +16,7 @@ class _DelayedResultCubit extends RequestCubit<String, String, Object?> {
 
   final Completer<RequestState<String, Object?>> resultState;
   final handleResultStarted = Completer<void>();
+  bool handleErrorCalled = false;
 
   @override
   Future<String> request() async => 'Result';
@@ -27,6 +28,14 @@ class _DelayedResultCubit extends RequestCubit<String, String, Object?> {
     }
 
     return resultState.future;
+  }
+
+  @override
+  Future<RequestErrorState<String, Object?>> handleError(
+    RequestErrorState<String, Object?> errorState,
+  ) async {
+    handleErrorCalled = true;
+    return errorState;
   }
 }
 
@@ -195,6 +204,24 @@ void main() {
           await runFuture;
         },
         expect: () => <RequestState<String, Object?>>[RequestLoadingState()],
+      );
+
+      blocTest<_DelayedResultCubit, RequestState<String, Object?>>(
+        'does not handle errors after close',
+        build: () => _DelayedResultCubit(
+          resultState: Completer<RequestState<String, Object?>>(),
+        ),
+        act: (cubit) async {
+          final runFuture = cubit.run();
+          await cubit.handleResultStarted.future;
+          await cubit.close();
+          cubit.resultState.completeError(Exception('Error'));
+          await runFuture;
+        },
+        expect: () => <RequestState<String, Object?>>[RequestLoadingState()],
+        verify: (cubit) {
+          expect(cubit.handleErrorCalled, isFalse);
+        },
       );
     });
   });

--- a/packages/leancode_cubit_utils/test/request_cubit_test.dart
+++ b/packages/leancode_cubit_utils/test/request_cubit_test.dart
@@ -160,52 +160,42 @@ void main() {
     });
 
     group('close', () {
-      test('cancels an ongoing request without emitting after close', () async {
-        final request = Completer<http.Response>();
-        when(
-          () => client.get(Uri.parse('delayed')),
-        ).thenAnswer((_) => request.future);
-        final cubit = TestRequestCubit(
-          'TestRequestCubit',
-          client: client,
-          id: 'delayed',
-        );
-        final states = <RequestState<String, int>>[];
-        final subscription = cubit.stream.listen(states.add);
+      late Completer<http.Response> request;
 
-        final runFuture = cubit.run();
-        await pumpEventQueue();
+      blocTest<TestRequestCubit, RequestState<String, int>>(
+        'cancels an ongoing request without emitting after close',
+        setUp: () {
+          request = Completer<http.Response>();
+          when(
+            () => client.get(Uri.parse('delayed')),
+          ).thenAnswer((_) => request.future);
+        },
+        build: () =>
+            TestRequestCubit('TestRequestCubit', client: client, id: 'delayed'),
+        act: (cubit) async {
+          final runFuture = cubit.run();
+          await pumpEventQueue();
+          await cubit.close();
+          request.complete(http.Response('Result', StatusCode.ok.value));
+          await runFuture;
+        },
+        expect: () => <RequestState<String, int>>[RequestLoadingState()],
+      );
 
-        expect(states, hasLength(1));
-        expect(states.single, isA<RequestLoadingState<String, int>>());
-
-        await cubit.close();
-        request.complete(http.Response('Result', StatusCode.ok.value));
-
-        await expectLater(runFuture, completes);
-        expect(states, hasLength(1));
-
-        await subscription.cancel();
-      });
-
-      test('does not emit when closed while handling a result', () async {
-        final resultState = Completer<RequestState<String, Object?>>();
-        final cubit = _DelayedResultCubit(resultState: resultState);
-        final states = <RequestState<String, Object?>>[];
-        final subscription = cubit.stream.listen(states.add);
-
-        final runFuture = cubit.run();
-        await cubit.handleResultStarted.future;
-
-        await cubit.close();
-        resultState.complete(RequestSuccessState('Result'));
-
-        await expectLater(runFuture, completes);
-        expect(states, hasLength(1));
-        expect(states.single, isA<RequestLoadingState<String, Object?>>());
-
-        await subscription.cancel();
-      });
+      blocTest<_DelayedResultCubit, RequestState<String, Object?>>(
+        'does not emit when closed while handling a result',
+        build: () => _DelayedResultCubit(
+          resultState: Completer<RequestState<String, Object?>>(),
+        ),
+        act: (cubit) async {
+          final runFuture = cubit.run();
+          await cubit.handleResultStarted.future;
+          await cubit.close();
+          cubit.resultState.complete(RequestSuccessState('Result'));
+          await runFuture;
+        },
+        expect: () => <RequestState<String, Object?>>[RequestLoadingState()],
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- Prevent `BaseRequestCubit` from emitting after it has been closed by guarding emits across async gaps.
- Cancel the in-flight request operation when the cubit closes.
- Add regression coverage for closing during a pending request and during async result handling.